### PR TITLE
fix: drop the root label from parsed hostnames

### DIFF
--- a/src/clean_url.js
+++ b/src/clean_url.js
@@ -15,6 +15,9 @@ const caretPath = (pathname) => {
   return `${path}?${search}`
 }
 
+// #150
+const stripRootLabel = (host) => host.replace(/\.+(?=(:\d+)?$)/, '')
+
 const safeLinks = [
   'safelinks\\.protection\\.outlook\\.com',
   '\\.protection\\.sophos\\.com',
@@ -113,7 +116,7 @@ for await (const line of createInterface({ input: process.stdin, terminal: false
     if (URL.canParse(`http://${line}`)) {
       const { hostname } = new URL(`http://${line}`)
 
-      console.log(hostname)
+      console.log(stripRootLabel(hostname))
     } else {
       const hostname = line
         // host
@@ -125,13 +128,13 @@ for await (const line of createInterface({ input: process.stdin, terminal: false
         // #2
         .split('?')[0]
 
-      console.log(hostname)
+      console.log(stripRootLabel(hostname))
     }
   } else {
     if (URL.canParse(line)) {
       const url = new URL(deSafelink(line))
 
-      url.host = url.host.replace(/^www\./, '')
+      url.host = stripRootLabel(url.host).replace(/^www\./, '')
 
       url.pathname = caretPath(url.pathname)
       const outUrl = `${url.host}${url.pathname}${url.search}`
@@ -140,9 +143,10 @@ for await (const line of createInterface({ input: process.stdin, terminal: false
 
       console.log(outUrl)
     } else {
-      const outUrl = caretPath(line)
+      const [host, ...path] = caretPath(line)
         // remove protocol
-        .split('/').slice(2).join('/')
+        .split('/').slice(2)
+      const outUrl = [stripRootLabel(host), ...path].join('/')
         // remove www
         .replace(/^www\./, '')
         // url encode space #11


### PR DESCRIPTION
Fixes #150.

A source URL may carry the DNS root label (`http://verify-att.app./…`). `new URL(…).hostname` keeps it, so `src/clean_url.js hostname` emits `verify-att.app.` and every generated format inherits the absolute name — the URL lists carry it too (`verify-att.app./path` in the uBO and AdGuard output).

Only the DNS formats break on it: in RPZ and in an unbound `local-zone` an absolute name is not a subdomain of the zone it is inserted into, so the entry is rejected and the whole zone fails to load.

Normalising once where the host is parsed keeps every format in agreement:

- `hostname` mode, both the parsed and the fallback branch;
- URL mode, before the `www.` strip;
- the non-parsable branch, on the authority only, so a path is untouched.

A port is preserved (`example.com.:8080/x` -> `example.com:8080/x`).

Checked against the current `src/clean_url.js` on Node 24:

| input | before | after |
|---|---|---|
| `verify-att.app./path` (hostname mode) | `verify-att.app.` | `verify-att.app` |
| `http://www.example.com./a/b` | `example.com./a/b` | `example.com/a/b` |
| `http://example.com.:8080/x` | `example.com.:8080/x` | `example.com:8080/x` |
| `https://example.com/ok` | unchanged | unchanged |
